### PR TITLE
Fix PHP notices when accessing not existing variable (MYSQL_* env)

### DIFF
--- a/Default.php
+++ b/Default.php
@@ -8,11 +8,21 @@ if (defined('CRON_TYPO3_ADDITIONALCONFIGURATION')) {
 
 require_once __DIR__ . '/ContextLoader.php';
 
-$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['dbname']   = $_ENV['MYSQL_DB']   ?? $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['dbname'];
-$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['host']     = $_ENV['MYSQL_HOST'] ?? $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['host'];
-$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['port']     = $_ENV['MYSQL_PORT'] ?? $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['port'];
-$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['user']     = $_ENV['MYSQL_USER'] ?? $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['user'];
-$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['password'] = $_ENV['MYSQL_PASS'] ?? $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['password'];
+if (isset($_ENV['MYSQL_DB'])) {
+    $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['dbname'] = $_ENV['MYSQL_DB'];
+}
+if (isset($_ENV['MYSQL_HOST'])) {
+    $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['host'] = $_ENV['MYSQL_HOST'];
+}
+if (isset($_ENV['MYSQL_PORT'])) {
+    $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['port'] = $_ENV['MYSQL_PORT'];
+}
+if (isset($_ENV['MYSQL_USER'])) {
+    $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['user'] = $_ENV['MYSQL_USER'];
+}
+if (isset($_ENV['MYSQL_PASS'])) {
+    $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['password'] = $_ENV['MYSQL_PASS'];
+}
 
 $confLoader = new \Cron\CronContext\ContextLoader();
 $confLoader


### PR DESCRIPTION
Happens for example during composer install time locally (no DB configured).

Running `composer install` without an ENV set locally on Mac for example could result in lots of stack traces with these kind of notices:
```
...
Notice: Undefined index: password in /Users/ernst/Developer/Projekte/uni-osnabrueck/uos-4g/private/typo3conf/ext/cron_context/Default.php on line 15
...
```