### PR TITLE
FIX: paths of undocumented caching feature

### DIFF
--- a/ContextLoader.php
+++ b/ContextLoader.php
@@ -116,7 +116,7 @@ class ContextLoader
     public function useCache()
     {
         // TODO: maybe the caching is not safe for race conditions
-        $this->cacheFile = Environment::getPublicPath() . '/typo3temp/var/Cache/Code/cache_phpcode/cron_context_conf.php';
+        $this->cacheFile = Environment::getVarPath() . '/cache/code/cron_context_conf.php';
 
         return $this;
     }


### PR DESCRIPTION
Stumbled upon that feature, activated it, saw it fail, ~~fixed it~~ corrected the paths.

To make this feature work we should probably hook into `$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc']` to flush the cache when somebody flush all caches.