### PR TITLE
Add support for ddev setups (v2 branch for TYPO3 v9, v10, v11)

### DIFF
--- a/Configuration/Development/DDEV.php
+++ b/Configuration/Development/DDEV.php
@@ -1,0 +1,13 @@
+<?php
+
+return array_merge(include __DIR__ . '/Docker.php',  [
+    'MAIL' => [
+        'transport' => 'smtp',
+        'transport_smtp_server' => 'localhost:1025'
+    ],
+    'SYS' => [
+        'reverseProxyHeaderMultiValue' => 'none',
+        'reverseProxyIP' =>  '*',
+        'reverseProxySSL' => '*',
+    ],
+]);

--- a/Configuration/Development/Docker.php
+++ b/Configuration/Development/Docker.php
@@ -11,16 +11,4 @@ return [
     'GFX' => [
         'processor' => 'GraphicsMagick',
     ],
-    'DB' => [
-        'Connections' => [
-            'Default' => [
-                'driver'   => 'mysqli',
-                'dbname'   => $_ENV['MYSQL_DB']   ?? 'typo3',
-                'host'     => $_ENV['MYSQL_HOST'] ?? 'mysql',
-                'port'     => $_ENV['MYSQL_PORT'] ?? '3306',
-                'user'     => $_ENV['MYSQL_USER'] ?? 'dev',
-                'password' => $_ENV['MYSQL_PASS'] ?? 'dev',
-            ],
-        ],
-    ],
 ];

--- a/Configuration/TypoScript/EnvironmentBanner/setup.typoscript
+++ b/Configuration/TypoScript/EnvironmentBanner/setup.typoscript
@@ -1,4 +1,4 @@
-[like(applicationContext, '/(Development|Test|Preview|Stage|Staging|Docker|VM)/')]
+[like(applicationContext, '/(Development|Test|Preview|Stage|Staging)/')]
 page.32524 = COA
 page.32524 {
     10 = TEXT
@@ -36,7 +36,7 @@ page.32524 {
     50.value = </div>
 }
 
-[like(applicationContext, '/Production\\/(Docker|VM)/')]
+[like(applicationContext, '/Production\\/(Docker|VM|DDEV)/')]
 # Non critical since it's only local -> green
 page.32524.30.value = background:green; color: #ffffff;
 

--- a/Default.php
+++ b/Default.php
@@ -8,6 +8,12 @@ if (defined('CRON_TYPO3_ADDITIONALCONFIGURATION')) {
 
 require_once __DIR__ . '/ContextLoader.php';
 
+if (isset($_ENV['DDEV_DATABASE_FAMILY'])) {
+    $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['dbname'] = 'db';
+    $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['host'] = 'db';
+    $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['user'] = 'db';
+    $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['password'] = 'db';
+}
 if (isset($_ENV['MYSQL_DB'])) {
     $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['dbname'] = $_ENV['MYSQL_DB'];
 }


### PR DESCRIPTION
Add support for a TYPO3_CONTEXT called `Development/DDEV` with correct mail, reverse proxy and database settings for an out-of-the-box ddev experience.

This change for older v2 branch of cron_context, compatible with TYPO3 v9, v10, v11.