### PR TITLE
Disable password policies to allow simple passwords for devs

### DIFF
--- a/Configuration/Development.php
+++ b/Configuration/Development.php
@@ -28,6 +28,10 @@ $logWriterConf = [
 ];
 $GLOBALS['TYPO3_CONF_VARS']['LOG'] = array_replace_recursive($GLOBALS['TYPO3_CONF_VARS']['LOG'], $logWriterConf);
 
+// Disable password policies (since it's annoying in dev contexts)
+$GLOBALS['TYPO3_CONF_VARS']['BE']['passwordPolicy'] = '';
+$GLOBALS['TYPO3_CONF_VARS']['FE']['passwordPolicy'] = '';
+
 return [
     'SYS' => [
         'trustedHostsPattern'  => '.*',


### PR DESCRIPTION
Since TYPO3 12 there's password policies. This makes any devs life miserable. Let's fix that ;-)

https://docs.typo3.org/m/typo3/reference-coreapi/12.4/en-us/ApiOverview/PasswordPolicies/Index.html#disable-password-policies-globally