### PR TITLE
Readd support for gone DB_* variables

### DIFF
--- a/Default.php
+++ b/Default.php
@@ -8,38 +8,51 @@ if (defined('CRON_TYPO3_ADDITIONALCONFIGURATION')) {
 
 require_once __DIR__ . '/ContextLoader.php';
 
-if (isset($_ENV['DDEV_DATABASE_FAMILY'])) {
-    $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['dbname'] = 'db';
-    $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['host'] = 'db';
-    $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['user'] = 'db';
-    $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['password'] = 'db';
-}
-if (isset($_ENV['MYSQL_DB'])) {
-    $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['dbname'] = $_ENV['MYSQL_DB'];
-}
-if (isset($_ENV['MYSQL_HOST'])) {
-    $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['host'] = $_ENV['MYSQL_HOST'];
-}
-if (isset($_ENV['MYSQL_PORT'])) {
-    $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['port'] = $_ENV['MYSQL_PORT'];
-}
-if (isset($_ENV['MYSQL_USER'])) {
-    $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['user'] = $_ENV['MYSQL_USER'];
-}
-if (isset($_ENV['MYSQL_PASS'])) {
-    $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['password'] = $_ENV['MYSQL_PASS'];
-}
+call_user_func(function() {
+    if (isset($_ENV['DDEV_DATABASE_FAMILY'])) {
+        // Hardcode defaults for a ddev installation
+        $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['dbname'] = 'db';
+        $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['host'] = 'db';
+        $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['user'] = 'db';
+        $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['password'] = 'db';
+    }
 
-$confLoader = new \Cron\CronContext\ContextLoader();
-$confLoader
+    foreach (['MYSQL_DB', 'DB_NAME', 'DB_DATABASE'] as $env) {
+        if (isset($_ENV[$env])) {
+            $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['dbname'] = $_ENV[$env];
+        }
+    }
+    foreach (['MYSQL_HOST', 'DB_HOST'] as $env) {
+        if (isset($_ENV[$env])) {
+            $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['host'] = $_ENV[$env];
+        }
+    }
+    foreach (['MYSQL_PORT', 'DB_PORT'] as $env) {
+        if (isset($_ENV[$env])) {
+            $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['port'] = $_ENV[$env];
+        }
+    }
+    foreach (['MYSQL_USER', 'DB_USER', 'DB_USERNAME'] as $env) {
+        if (isset($_ENV[$env])) {
+            $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['user'] = $_ENV[$env];
+        }
+    }
+    foreach (['MYSQL_PASS', 'DB_PASS', 'DB_PASSWORD'] as $env) {
+        if (isset($_ENV[$env])) {
+            $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['password'] = $_ENV[$env];
+        }
+    }
+
+    $confLoader = new \Cron\CronContext\ContextLoader();
+    $confLoader
         // Add EXT:cron_context default context configuration
-    ->addContextConfiguration(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3conf/ext/cron_context/Configuration/')
+        ->addContextConfiguration(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3conf/ext/cron_context/Configuration/')
         // Add project context configuration
-    ->addContextConfiguration(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3conf/AdditionalConfiguration')
+        ->addContextConfiguration(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3conf/AdditionalConfiguration')
         // Add local configuration
-    ->addConfiguration(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3conf/AdditionalConfiguration/Local.php')
+        ->addConfiguration(\TYPO3\CMS\Core\Core\Environment::getPublicPath() . '/typo3conf/AdditionalConfiguration/Local.php')
         // Load configuration files
-    ->loadConfiguration()
+        ->loadConfiguration()
         // Add context name to sitename (if in development context)
-    ->appendContextNameToSitename();
-unset($confLoader);
+        ->appendContextNameToSitename();
+});

--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ TYPO3_CONTEXT=Production/Live/Server4711 (specific live server configuration):
 
 cron_context will read the TYPO3 DB credentials from the following environment variables if present:
 
-* MYSQL_DB
-* MYSQL_HOST
-* MYSQL_PORT
-* MYSQL_USER
-* MYSQL_PASS
+* MYSQL_DB or DB_NAME
+* MYSQL_HOST or DB_HOST
+* MYSQL_PORT or DB_PORT
+* MYSQL_USER or DB_USER
+* MYSQL_PASS or DB_PASS
 
 ## Advanced usage
 


### PR DESCRIPTION
We now support regardless of the context:

* MYSQL_DB or DB_NAME
* MYSQL_HOST or DB_HOST
* MYSQL_PORT or DB_PORT (new)
* MYSQL_USER or DB_USER
* MYSQL_PASS or DB_PASS